### PR TITLE
Only allow fansi.Str auto-construction for string literals

### DIFF
--- a/fansi/src/fansi/Fansi.scala
+++ b/fansi/src/fansi/Fansi.scala
@@ -224,7 +224,7 @@ object Str{
     * Make the construction of [[fansi.Str]]s from `String`s and other
     * `CharSequence`s automatic
     */
-  implicit def implicitApply(raw: CharSequence): fansi.Str = apply(raw)
+  implicit def implicitApply(raw: String with Singleton): fansi.Str = apply(raw)
 
   /**
     * Regex that can be used to identify Ansi escape patterns in a string.

--- a/fansi/test/src/fansi/FansiTests.scala
+++ b/fansi/test/src/fansi/FansiTests.scala
@@ -276,7 +276,7 @@ object FansiTests extends TestSuite{
           println()
         }
         test - check(
-          "#" + fansi.Color.True(127, 126, 0)("lol") + "omg" + fansi.Color.True(127, 126, 0)("wtf")
+          fansi.Str("#") ++ fansi.Color.True(127, 126, 0)("lol") ++ "omg" ++ fansi.Color.True(127, 126, 0)("wtf")
         )
 
         test - square(for(i <- 0 to 255) yield fansi.Color.True(i,i,i))
@@ -438,6 +438,10 @@ object FansiTests extends TestSuite{
           fansi.Color.Red != fansi.Bold.On ++ fansi.Color.Red
         )
       }
+    }
+    test("implicitConstructorOnlyForLiterals"){
+      compileError("""{val x = ""; x: fansi.Str }""")
+      "": fansi.Str
     }
 //    test("perf"){
 //      val input = s"+++$R---$G***$B///" * 1000


### PR DESCRIPTION
Having the implicit constructor apply to any `CharSequence` is dangerous, as often `CharSequence`s have unknown contents and the construction of a `fansi.Str` might fail (configurable to mean throw, strip, or sanitize) if it contains weird escapes. On the other hand, having to wrap every string literal in a `fansi.Str()` constructor is tedious.

This PR makes it so that only string literals can be auto-converted to `fansi.Str`s, as we can be 99.99% sure string literals in the Scala source code do not contain weird escapes that might cause the `fansi.Str` constructor to fail. For string variables which do not have known contents, we force the user to wrap them explicitly, to ensure the points at which we are doing a potentially-unsafe conversion are explicit and the user has a chance to specify the `ErrorMode`.