### PR TITLE
Clean up fansi.Str constructors

### DIFF
--- a/fansi/src/fansi/Fansi.scala
+++ b/fansi/src/fansi/Fansi.scala
@@ -354,15 +354,25 @@ object Str{
     new fansi.Str(chars.clone(), colors.clone())
   }
 
-  def apply(args: Str*) = {
+  def apply(args: Str*): fansi.Str = {
     join(args)
   }
-  def join(args: TraversableOnce[Str]) = {
-    val length = args.iterator.map(_.length).sum
+  def join(args: Iterable[Str], sep: fansi.Str = fansi.Str("")) = {
+    val length = args.iterator.map(_.length + sep.length).sum - sep.length
     val chars = new Array[Char](length)
     val colors = new Array[State](length)
     var j = 0
     for (arg <- args){
+
+      if (j != 0){
+        var k = 0
+        while (k < sep.length){
+          chars(j) = sep.getChar(k)
+          colors(j) = sep.getColors(k)
+          j += 1
+          k += 1
+        }
+      }
       var i = 0
       while (i < arg.length){
         chars(j) = arg.getChar(i)

--- a/fansi/src/fansi/Fansi.scala
+++ b/fansi/src/fansi/Fansi.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
   * giving 20% (on `++`) to >1000% (on `splitAt`, `subString`
   * and `Str.parse`) speedups
   */
-case class Str private(private val chars: Array[Char], private val colors: Array[Str.State]) {
+class Str private(private val chars: Array[Char], private val colors: Array[Str.State]) {
   require(chars.length == colors.length)
   override def hashCode() = util.Arrays.hashCode(chars) + util.Arrays.hashCode(colors)
   override def equals(other: Any) = other match{
@@ -42,7 +42,7 @@ case class Str private(private val chars: Array[Char], private val colors: Array
     System.arraycopy(colors, 0, colors2, 0, length)
     System.arraycopy(other.colors, 0, colors2, length, other.length)
 
-    Str(chars2, colors2)
+    new Str(chars2, colors2)
   }
 
   /**
@@ -335,7 +335,7 @@ object Str{
       }
     }
 
-    Str(
+    new Str(
       util.Arrays.copyOfRange(chars, 0, destIndex),
       util.Arrays.copyOfRange(colors, 0, destIndex)
     )
@@ -354,7 +354,10 @@ object Str{
     new fansi.Str(chars.clone(), colors.clone())
   }
 
-  def join(args: Str*) = {
+  def apply(args: Str*) = {
+    join(args)
+  }
+  def join(args: TraversableOnce[Str]) = {
     val length = args.iterator.map(_.length).sum
     val chars = new Array[Char](length)
     val colors = new Array[State](length)

--- a/fansi/test/src/fansi/FansiTests.scala
+++ b/fansi/test/src/fansi/FansiTests.scala
@@ -43,8 +43,14 @@ object FansiTests extends TestSuite{
 
       assert(concated == expected)
     }
+    test("apply"){
+      val concated = fansi.Str(fansi.Str(rgbOps), fansi.Str(rgbOps)).render
+      val expected = rgbOps ++ RTC ++ rgbOps ++ RTC
+
+      assert(concated == expected)
+    }
     test("join"){
-      val concated = fansi.Str.join(fansi.Str(rgbOps), fansi.Str(rgbOps)).render
+      val concated = fansi.Str.join(Seq(fansi.Str(rgbOps), fansi.Str(rgbOps))).render
       val expected = rgbOps ++ RTC ++ rgbOps ++ RTC
 
       assert(concated == expected)

--- a/fansi/test/src/fansi/FansiTests.scala
+++ b/fansi/test/src/fansi/FansiTests.scala
@@ -48,12 +48,35 @@ object FansiTests extends TestSuite{
       val expected = rgbOps ++ RTC ++ rgbOps ++ RTC
 
       assert(concated == expected)
+
+      val concated2 = fansi.Str("hello", "world", "i am cow")
+      val concated3 = fansi.Str("helloworld", "i am cow")
+      assert(concated2 == concated3)
+
+      val applied = fansi.Str("hello")
+      assert(applied.plainText == "hello")
+      assert(applied.getColors.forall(_ == 0))
     }
     test("join"){
       val concated = fansi.Str.join(Seq(fansi.Str(rgbOps), fansi.Str(rgbOps))).render
       val expected = rgbOps ++ RTC ++ rgbOps ++ RTC
-
       assert(concated == expected)
+
+      val concated2 = fansi.Str.join(Seq(fansi.Str(rgbOps), fansi.Str("xyz"))).render
+      val expected2 = rgbOps ++ RTC ++ "xyz"
+      assert(concated2 == expected2)
+
+      val concated3 = fansi.Str.join(Seq(fansi.Str(rgbOps)), sep = "lol").render
+      val expected3 = rgbOps ++ RTC
+      assert(concated3 == expected3)
+
+      val concated4 = fansi.Str.join(Seq(fansi.Str(rgbOps), fansi.Str("xyz")), sep = "lol").render
+      val expected4 = rgbOps ++ RTC ++ "lol" ++ "xyz"
+      assert(concated4 == expected4)
+
+      val concated5 = fansi.Str.join(Seq(fansi.Str(rgbOps), fansi.Str("xyz"), fansi.Str(rgbOps)), sep = "lol").render
+      val expected5 = rgbOps ++ RTC ++ "lol" ++ "xyz" ++ "lol" ++ rgbOps ++ RTC
+      assert(concated5 == expected5)
     }
     test("get"){
       val str = fansi.Str(rgbOps)


### PR DESCRIPTION
- Remove `case` modifier from `fansi.Str`: we're already overriding apply, equals, hashcode, etc. so being a `case class` buys us nothing.

- Rename `fansi.Str.join` to `fansi.Str.apply`, to provide an easy way of concatenating a bunch of string literals e.g. `fansi.Str("hello", "world", "i am cow")`

- Added a new `fansi.Str.join` method that takes a `Seq[fansi.Str]`, to make it a bit more ergonomic to join such `Seq`s together. Also include an optional `sep` argument, to handle the use case that `mkString` satisfies on `Seq[String]`

This is a breaking change, so since we're already breaking compat in a few places in com-lihaoyi we should include this in the update

Review by @lolgab 